### PR TITLE
Allow useLenis() with no arguments

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,7 +26,7 @@ function useCurrentLenis() {
   return local ?? root
 }
 
-export function useLenis(callback, deps = [], priority = 0) {
+export function useLenis(callback = undefined, deps = [], priority = 0) {
   const { lenis, addCallback, removeCallback } = useCurrentLenis()
 
   useEffect(() => {


### PR DESCRIPTION
I'd expect to be able to use the useLenis hook with no parameters, for example as seen in the following code snippet:

```
const lenis = useLenis();
const href = `${id}`;

return (
    <NavLinkElement href={href} onClick={() => lenis.scrollTo(href)}>
```

This pr readds the fallback to undefined from [dbc49eb](https://github.com/studio-freight/react-lenis/commit/dbc49ebb7cdda94cf3c67e99773ee739aa6b8fc5), hopefully allowing useLenis() to be called without a given callback.